### PR TITLE
fix: VyOS Ansible接続をlibsshに変更

### DIFF
--- a/terraform/prd/ansible.cfg
+++ b/terraform/prd/ansible.cfg
@@ -1,5 +1,4 @@
 [defaults]
-interpreter_python=/usr/bin/python3
 # Disable implicit Gathering Facts
 gathering=explicit
 vault_password_file=./ansible/files/get_vault_password.sh
@@ -11,3 +10,6 @@ become_flags = -H -S
 
 [ssh_connection]
 ssh_args = -o ServerAliveInterval=120 -o TCPKeepAlive=yes -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ForwardAgent=yes
+
+[persistent_connection]
+ssh_type = libssh

--- a/terraform/prd/ansible/inventory_vyos.yaml
+++ b/terraform/prd/ansible/inventory_vyos.yaml
@@ -3,6 +3,7 @@ vyos_router:
     ansible_network_os: vyos.vyos.vyos
     ansible_connection: ansible.netcommon.network_cli
     ansible_user: vyos
+    ansible_python_interpreter: python3
   hosts:
     prd-vyo-01:
       ansible_host: 192.168.20.4


### PR DESCRIPTION
## 概要

- `ansible.cfg` からグローバルな `interpreter_python=/usr/bin/python3` を削除
- `[persistent_connection]` セクションに `ssh_type = libssh` を追加して、VyOS playbook実行時にpylibsshを使用するよう変更
- `inventory_vyos.yaml` に `ansible_python_interpreter: python3` を追加し、venv Pythonが使用されるよう明示的に指定

## 背景

VyOS playbook実行時に `ansible-connection` デーモンがシステムPython (`/usr/bin/python3`) を使用してしまい、pylibsshがインストールされていないためparamikoフォールバックが発生していた問題を修正。