### PR TITLE
chore: cloud_init_config__zabbix_serverのmovedブロックを削除

### DIFF
--- a/terraform/prd/zabbix_servers.tf
+++ b/terraform/prd/zabbix_servers.tf
@@ -60,11 +60,6 @@ resource "terraform_data" "cloud_init_config__zabbix_server" {
   }
 }
 
-moved {
-  from = null_resource.cloud_init_config__zabbix_server
-  to   = terraform_data.cloud_init_config__zabbix_server
-}
-
 resource "proxmox_vm_qemu" "zabbix_server" {
   for_each   = local.vm_settings__zabbix_server
   depends_on = [terraform_data.cloud_init_config__zabbix_server]


### PR DESCRIPTION
## 概要

- `null_resource.cloud_init_config__zabbix_server` → `terraform_data.cloud_init_config__zabbix_server` のリソース移行が完了したため、`moved` ブロックを削除

## 背景

PR #311 で `-replace` フラグを使って移行を適用済み。移行完了後は `moved` ブロックが不要になるため削除。