### PR TITLE
fix: DNSサーバのIPアドレス設定とcloud-initのDNS設定を修正

### DIFF
--- a/terraform/prd/cloud-init/prd-dsq_cloud-init.yaml.tftpl
+++ b/terraform/prd/cloud-init/prd-dsq_cloud-init.yaml.tftpl
@@ -19,6 +19,10 @@ users:
     home: /home/${CI_MACHINEUSER_NAME}
     ssh_authorized_keys:
       - ${CI_MACHINEUSER_SSH_PUBKEY}
+manage_resolv_conf: true
+resolv_conf:
+  nameservers:
+    - 192.168.20.17
 keyboard:
   layout: us
   model: pc105


### PR DESCRIPTION
## 変更内容

- `dns_servers.tf`: `/28` サブネット (`192.168.20.16/28`) に対して `dmz_nw_host_section` が範囲外 (`22`) だったため、サブネット内の相対ホスト番号 (`6`) に修正（`192.168.20.22` を割り当て）
- `cloud-init/prd-dsq_cloud-init.yaml.tftpl`: `manage_resolv_conf` と `resolv_conf` を追加し、ネームサーバ `192.168.20.17` を設定