### PR TITLE
fix: RenovateのPython除外設定をPython本体のみに限定する

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,7 +5,7 @@
   ],
   "packageRules": [
     {
-      "matchCategories": [
+      "matchPackageNames": [
         "python"
       ],
       "enabled": false


### PR DESCRIPTION
## Summary

- `matchCategories: ["python"]` → `matchPackageNames: ["python"]` に変更
- Python本体（`.python-version`、`requires-python`）は引き続き更新対象外
- `ansible`、`bcrypt` 等のPythonライブラリは更新対象に戻る

Closes #346

🤖 Generated with [Claude Code](https://claude.com/claude-code)